### PR TITLE
add allowance for port to be set for pg dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Attach a target postgres container to this container and mount a volume to conta
 | `PGPASSWORD` | Optional | `None` | The password for accessing the database |
 | `PGDB` | Optional | postgres | The name of the database |
 | `PGHOST` | Optional | db | The hostname of the database |
+| `PGPORT` | Optional | `5432` | The port for the database |
 | `CRON_SCHEDULE` | Required | 0 1 * * * | The cron schedule at which to run the pg_dump |
 | `DELETE_OLDER_THAN` | Optional | `None` | Optionally, delete files older than `DELETE_OLDER_THAN` minutes. Do not include `+` or `-`. |
 

--- a/dump.sh
+++ b/dump.sh
@@ -7,7 +7,7 @@ echo "Job started: $(date)"
 DATE=$(date +%Y%m%d_%H%M%S)
 FILE="/dump/$PREFIX-$DATE.sql"
 
-pg_dump -h "$PGHOST" -U "$PGUSER" -f "$FILE" -d "$PGDB"
+pg_dump -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -f "$FILE" -d "$PGDB" 
 gzip "$FILE"
 
 if [ ! -z "$DELETE_OLDER_THAN" ]; then

--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,7 @@ PREFIX=${PREFIX:-dump}
 PGUSER=${PGUSER:-postgres}
 PGDB=${PGDB:-postgres}
 PGHOST=${PGHOST:-db}
+PGPORT=${PGPORT:-5432}
 
 
 if [[ "$COMMAND" == 'dump' ]]; then
@@ -17,7 +18,7 @@ elif [[ "$COMMAND" == 'dump-cron' ]]; then
     if [[ ! -e "$LOGFIFO" ]]; then
         mkfifo "$LOGFIFO"
     fi
-    CRON_ENV="PREFIX='$PREFIX'\nPGUSER='$PGUSER'\nPGDB='$PGDB'\nPGHOST='$PGHOST'"
+    CRON_ENV="PREFIX='$PREFIX'\nPGUSER='$PGUSER'\nPGDB='$PGDB'\nPGHOST='$PGHOST'\nPGPORT='$PGPORT'"
     if [ -n "$PGPASSWORD" ]; then
         CRON_ENV="$CRON_ENV\nPGPASSWORD='$PGPASSWORD'"
     fi


### PR DESCRIPTION
this image would not work if one was using a port that was not the default (5432)
This has added a pgport env variable to the dump, so that one can specify their own port